### PR TITLE
Remove NVMe and format table

### DIFF
--- a/docs/content/en/reference/instance_types.md
+++ b/docs/content/en/reference/instance_types.md
@@ -206,10 +206,10 @@ Information in this document is provided in the following units:
 
 |                     |        |
 |---------------------|--------|
-| **Memory**          | GiB     |
-| **Disk**            | GiB     |
+| **Memory**          | GiB    |
+| **Disk**            | GiB    |
 | **Bandwidth**       | Gbit/s |
-| **Disk Throughput** | GiB/s   |
+| **Disk Throughput** | GiB/s  |
 
 <!-- References -->
 

--- a/docs/content/en/reference/instance_types.md
+++ b/docs/content/en/reference/instance_types.md
@@ -200,13 +200,6 @@ summarised in the table below:
 | rdb\_fast | 1500         | 10000      | 0.25               | 0.5              |
 | ssd       | 10000        | 10000      | 0.75               | 0.75             |
 
-{{% alert color="info" %}}
-
-Our `ssd` class is currently based on NVMe.
-
-{{% /alert %}}
-
-
 ### Units
 
 Information in this document is provided in the following units:


### PR DESCRIPTION
Mentioning NVMe is an unnecessary technical detail.