### PR TITLE
Update Docsy Theme from 0.7.0 to 0.9.1

### DIFF
--- a/docs/go.mod
+++ b/docs/go.mod
@@ -2,4 +2,7 @@ module github.com/wavecon/wavestack/docs
 
 go 1.20
 
-require github.com/google/docsy v0.7.0 // indirect
+require (
+	github.com/google/docsy v0.9.1 // indirect
+	github.com/google/docsy/dependencies v0.7.2 // indirect
+)

--- a/docs/go.sum
+++ b/docs/go.sum
@@ -1,10 +1,15 @@
 github.com/FortAwesome/Font-Awesome v0.0.0-20220831210243-d3a7818c253f/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/FortAwesome/Font-Awesome v0.0.0-20230327165841-0698449d50f2/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
+github.com/FortAwesome/Font-Awesome v0.0.0-20240108205627-a1232e345536/go.mod h1:IUgezN/MFpCDIlFezw3L8j83oeiIuYoj28Miwr/KUYo=
 github.com/google/docsy v0.6.0 h1:43bVF18t2JihAamelQjjGzx1vO2ljCilVrBgetCA8oI=
 github.com/google/docsy v0.6.0/go.mod h1:VKKLqD8PQ7AglJc98yBorATfW7GrNVsn0kGXVYF6G+M=
 github.com/google/docsy v0.7.0 h1:JaeZ0/KufX/BJ3SyATb/fmZa1DFI7o5d9KU+i6+lLJY=
 github.com/google/docsy v0.7.0/go.mod h1:5WhIFchr5BfH6agjcInhpLRz7U7map0bcmKSpcrg6BE=
+github.com/google/docsy v0.9.1 h1:+jqges1YCd+yHeuZ1BUvD8V8mEGVtPxULg5j/vaJ984=
+github.com/google/docsy v0.9.1/go.mod h1:saOqKEUOn07Bc0orM/JdIF3VkOanHta9LU5Y53bwN2U=
 github.com/google/docsy/dependencies v0.6.0/go.mod h1:EDGc2znMbGUw0RW5kWwy2oGgLt0iVXBmoq4UOqstuNE=
 github.com/google/docsy/dependencies v0.7.0/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
+github.com/google/docsy/dependencies v0.7.2 h1:+t5ufoADQAj4XneFphz4A+UU0ICAxmNaRHVWtMYXPSI=
+github.com/google/docsy/dependencies v0.7.2/go.mod h1:gihhs5gmgeO+wuoay4FwOzob+jYJVyQbNaQOh788lD4=
 github.com/twbs/bootstrap v4.6.2+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=
 github.com/twbs/bootstrap v5.2.3+incompatible/go.mod h1:fZTSrkpSf0/HkL0IIJzvVspTt1r9zuf7XlZau8kpcY0=

--- a/docs/hugo.yaml
+++ b/docs/hugo.yaml
@@ -22,8 +22,9 @@ languages:
     title: "Wavestack"
     languageName: "English"
     weight: 1
-    time_format_default: "2006-01-02"
-    time_format_blog: "2006-01-02"
+    params:
+      time_format_default: "2006-01-02"
+      time_format_blog: "2006-01-02"
 
 markup:
   goldmark:
@@ -48,7 +49,7 @@ params:
 
   ui:
     breadcrumb_disable: false
-    footer_about_disable: false
+    footer_about_enable: true
     navbar_logo: true
     navbar_translucent_over_cover_disable: false
     sidebar_menu_compact: false

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,7 +7,7 @@
   command = "make build"
 
 [build.environment]
-  HUGO_VERSION = "0.111.3"
+  HUGO_VERSION = "0.124.1"
   NODE_VERSION = "20"
   GO_VERSION = "1.20"
 


### PR DESCRIPTION
### Purpose

This pull request updates the Docsy theme from version 0.7.0 to 0.9.1 in our Hugo project. It also addresses and resolves deprecated configuration settings in hugo.yaml to ensure compatibility with the new version and to leverage improved functionality and security features of the updated theme.

### Major Changes

- Updated Docsy Version
    - Modified go.mod and go.sum to upgrade Docsy to v0.9.1.
- Fixed Deprecated Configuration
    - Adjusted settings within hugo.yaml to align with the new Docsy/Hugo requirements.