### PR TITLE
Major Updates to Alert Styles

### DIFF
--- a/docs/assets/scss/_styles_project.scss
+++ b/docs/assets/scss/_styles_project.scss
@@ -68,10 +68,22 @@ table, tr, td {
     color: $white!important
 }
 
-.alert, pre {
-    background: linear-gradient(112.4deg,rgba(48,190,255,.1) 13%,rgba(0,0,0,0) 100%),linear-gradient(72.04deg,rgba(48,190,255,.1) 0,rgba(19,35,59,.022) 46.74%,rgba(48,190,255,.1) 100%),rgba(48,190,255,.17)!important;
-    border-radius: $radius-l;
-    border: none!important;
+.alert, .alert.alert-info, pre {
+  background: linear-gradient(112.4deg,rgba(48,190,255,.1) 13%,rgba(0,0,0,0) 100%),linear-gradient(72.04deg,rgba(48,190,255,.1) 0,rgba(19,35,59,.022) 46.74%,rgba(48,190,255,.1) 100%),rgba(48,190,255,.17)!important;
+  border-radius: $radius-l;
+  border: none!important;
+}
+
+.alert.alert-warning {
+  background: linear-gradient(112.4deg, rgba(255, 235, 59, .1) 13%, rgba(0, 0, 0, 0) 100%), linear-gradient(72.04deg, rgba(255, 235, 59, .1) 0, rgba(59, 55, 19, .022) 46.74%, rgba(255, 235, 59, .1) 100%), rgba(255, 235, 59, .17) !important;
+}
+
+.alert.alert-danger, .alert.alert-error {
+  background: linear-gradient(112.4deg, rgba(255, 59, 59, .1) 13%, rgba(0, 0, 0, 0) 100%), linear-gradient(72.04deg, rgba(255, 59, 59, .1) 0, rgba(59, 19, 19, .022) 46.74%, rgba(255, 59, 59, .1) 100%), rgba(255, 59, 59, .17) !important;
+}
+
+.alert.alert-success {
+  background: linear-gradient(112.4deg, rgba(0, 255, 140, .1) 13%, rgba(0, 0, 0, 0) 100%), linear-gradient(72.04deg, rgba(0, 255, 140, .1) 0, rgba(19, 35, 59, .022) 46.74%, rgba(0, 255, 140, .1) 100%), rgba(0, 255, 140, .17) !important;
 }
 
 .td-content pre > code {

--- a/docs/content/en/compute/instance_types.md
+++ b/docs/content/en/compute/instance_types.md
@@ -124,7 +124,7 @@ Typical workloads:
 - Key-value stores (e.g. etcd)
 - Kubernetes controlplane nodes
 
-{{% alert color="warning" %}}
+{{% alert color="danger" %}}
 
 Please note that local storage is ephemeral, which means that data
 stored on these volumes is lost if the instance is destroyed.
@@ -164,7 +164,7 @@ Instance types with NVIDIA A30 Tensor Core GPUs are currently only offered in th
 |-------------------------|------|--------|------|-----------|-------------------|----------------|------|
 | SCS-16V-64-500s_GNa-14h | 16   | 64     | 500  | ssd       | 2.5               | 10             | 6    |
 
-{{% alert color="info" %}}
+{{% alert color="success" %}}
 
 Please [get in touch with our support](../../support) if you
 require differently sized GPU based instances!

--- a/docs/content/en/support/maintenance.md
+++ b/docs/content/en/support/maintenance.md
@@ -28,7 +28,7 @@ unforeseen negative impact. If applicable, we will roll out changes
 separately in individual zones, which ensures the availability of at
 least two zones at any given point in time.
 
-{{% alert color="warning" %}}
+{{% alert color="danger" %}}
 Please note that urgent security-upgrades may be performed outwith
 these maintenance windows.
 {{% /alert %}}


### PR DESCRIPTION
#### Changes

This pull request updates how alerts look and how they are used in our documentation. Here are the main updates:
- Added new color gradients to alerts to make them look different: `alert-info`, `alert-warning`, `alert-danger`, `alert-error`, `alert-success`.
- Changed some texts in the documentation to use the `danger` and `success` alerts instead of `warning` and `info`. This helps to communicate urgency and success more clearly.

#### Motivation

These changes are made to make sure alerts are easier to tell apart and the information they carry is clearer, especially in our technical documents.


#### Impact
With clearer differences between types of alerts and their better use in our documents, readers can understand important details faster and avoid confusion.
