### PR TITLE
rename and refactore IAM documentation structure

### DIFF
--- a/docs/content/en/iam/adv_role_mng.md
+++ b/docs/content/en/iam/adv_role_mng.md
@@ -1,23 +1,22 @@
 ---
-title: "Advanced Role and Permission Concept"
+title: "Advanced Role and Permission Management"
 linkTitle: "Advanced Roles"
-weight: 2
+weight: 400
 description: >
   Guide to creating and configuring application credentials in Wavestack for managing VMs, images, and networks.
 ---
 
-## Advanced Role and Permission Concept
+While basic role management works well for most standard use cases, advanced scenarios may require more control.
+[Application Credentials](https://docs.openstack.org/keystone/latest/user/application_credentials.html) give you more flexibility in defining roles and more precise control over how you manage
+VMs, images, and networks in Wavestack. This guide will walk you through creating and configuring these credentials to
+manage virtual machines (VMs), images, and networks effectively.
 
-[Application Credentials](https://docs.openstack.org/keystone/latest/user/application_credentials.html) are a powerful way to define and assign roles flexibly and granularly in Wavestack. This guide
-will walk you through creating and configuring these credentials to manage virtual machines (VMs), images, and networks
-effectively.
-
-### Scope
+## Scope
 
 Managing volumes is out of scope for this guide. You can still create functioning VMs without any problems.
 Connectivity to external networks is also out of scope for this guide (internal networking works completely fine). Creating ports is also out of scope, but you can add existing ports to routers. Please contact your network admin if you need help setting up this kind of things.
 
-### Steps to Create an Application Credential
+## Steps to Create an Application Credential
 
 1. Navigate to Identity - Application Credentials in the [Wavestack Dashboard](https://dashboard.wavestack.de/identity/application_credentials/) and click on `Create Application Credential`.
 
@@ -39,7 +38,7 @@ Connectivity to external networks is also out of scope for this guide (internal 
   additional application credentials or keystone trusts. If your application credential needs to be able to perform
   these actions, check `Unrestricted`. However, this is generally not recommended for security purposes.
 
-### Example Configuration for VM Management
+## Example Configuration for VM Management
 
 ```json
 [
@@ -136,7 +135,7 @@ Connectivity to external networks is also out of scope for this guide (internal 
 ]
 ```
 
-### Example Configuration for Image Management
+## Example Configuration for Image Management
 
 ```json
 [
@@ -223,7 +222,7 @@ Connectivity to external networks is also out of scope for this guide (internal 
 ]
 ```
 
-### Example Configuration for Network Management
+## Example Configuration for Network Management
 
 ```json
 [
@@ -445,7 +444,7 @@ Connectivity to external networks is also out of scope for this guide (internal 
 ]
 ```
 
-### Comprehensive Example
+## Comprehensive Example
 
 Here is a comprehensive configuration that includes VM management, image management, and network management:
 
@@ -846,7 +845,7 @@ Here is a comprehensive configuration that includes VM management, image managem
 ]
 ```
 
-### Additional Information
+## Additional Information
 
 For more information, visit the [OpenStack Application Credentials documentation](https://docs.openstack.org/keystone/latest/user/application_credentials.html).
 

--- a/docs/content/en/iam/project_mng.md
+++ b/docs/content/en/iam/project_mng.md
@@ -3,7 +3,7 @@ title: "Project Management"
 linkTitle: "Project Management"
 description: "Manage projects on Wavestack"
 type: "docs"
-weight: 2
+weight: 200
 ---
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright (C) 2023 Wavecon GmbH -->

--- a/docs/content/en/iam/role_mng.md
+++ b/docs/content/en/iam/role_mng.md
@@ -3,7 +3,7 @@ title: "Role Management"
 linkTitle: "Role Management"
 description: "Manage user roles on Wavestack"
 type: "docs"
-weight: 3
+weight: 300
 ---
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright (C) 2023 Wavecon GmbH -->

--- a/docs/content/en/iam/user_mng.md
+++ b/docs/content/en/iam/user_mng.md
@@ -3,7 +3,7 @@ title: "User Management"
 linkTitle: "User Management"
 description: "Manage Users on Wavestack"
 type: "docs"
-weight: 1
+weight: 100
 ---
 <!-- SPDX-License-Identifier: CC-BY-4.0 -->
 <!-- Copyright (C) 2023 Wavecon GmbH -->


### PR DESCRIPTION
This PR focuses on reorganizing the IAM documentation for better structure and readability:

- File rename: Moved and renamed `docs/content/en/compute/app_cred.md` to `docs/content/en/iam/adv_role_mng.md`, aligning with the new emphasis on advanced role and permission management, including application credentials.
- Content enhancements: Updated titles, descriptions, and headings in the advanced role management guide to provide a clearer structure.
- Weight adjustments: Reordered the weights of various IAM documentation files (`project_mng.md`, `role_mng.md`, `user_mng.md`) for a more logical sidebar navigation experience.