### PR TITLE
serve inside docker container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ help:  ## Show help/usage information
 serve-docs: ## Run documentation preview server
 	$(MAKE) -C docs serve
 
+serve-docker: ## Run documentation preview server inside docker
+	$(MAKE) -C docs serve-docker
+
 build-docs: ## Build documentation
 	$(MAKE) -C docs build
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -22,6 +22,14 @@ build: deps ## Build documentation
 		--minify \
 		--enableGitInfo
 
+serve-docker: ## Run documentation preview server inside docker
+	docker run -it --rm --name hugo \
+		-v $(shell pwd):/src -p 1313:1313 \
+		hugomods/hugo server \
+		--buildDrafts \
+		--buildFuture \
+		--disableFastRender
+
 build-preview: deps ## Build documentation (preview environment)
 	hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \


### PR DESCRIPTION
when working locally you might not want to install npm or hugo. now you can use `make serve-docker` to run inside `hugomods/hugo` locally.