### PR TITLE
Add storage comparison

### DIFF
--- a/docs/content/en/storage/comparison.md
+++ b/docs/content/en/storage/comparison.md
@@ -1,0 +1,11 @@
+| Feature                | Cinder ("rbd-fast")                  | LUKS (based on Cinder)                    | S3 (Object Storage)                                |
+|------------------------|--------------------------------------|-------------------------------------------|----------------------------------------------------|
+| **Type**               | Block storage                        | Encrypted block storage                   | Object-based cloud storage                         |
+| **Provisioning**       | StorageClass: `rbd-fast`             | StorageClass: `luks`                      | OpenStack API, web console, CLI                    |
+| **Access Pattern**     | ReadWriteOnce (RWO)                  | ReadWriteOnce (RWO)                       | HTTP(S), REST API, global, similar to RWX          |
+| **Availability**       | Within a single zone                 | Within a single zone                      | Global                                             |
+| **Redundancy**         | Zone-internal                        | Zone-internal                             | Cross-zone, geo-redundant                          |
+| **Encryption**         | No                                   | Default, strong encryption                | Optional (server-side or client-side encryption)   |
+| **Access Control**     | OpenStack/Kubernetes roles           | OpenStack/Kubernetes roles                | IAM, ACLs, bucket policies                         |
+| **Backup**             | Managed by customer                  | Managed by customer                       | Managed by customer                                |
+| **Typical Use Cases**  | Persistent volumes for VMs/containers| Encrypted persistent volumes              | Backup, archiving, web applications, data lakes    |

--- a/docs/content/en/storage/comparison.md
+++ b/docs/content/en/storage/comparison.md
@@ -5,7 +5,7 @@
 | **Access Pattern**     | ReadWriteOnce (RWO)                  | ReadWriteOnce (RWO)                       | HTTP(S), REST API, global, similar to RWX          |
 | **Availability**       | Within a single zone                 | Within a single zone                      | Global                                             |
 | **Redundancy**         | Zone-internal                        | Zone-internal                             | Cross-zone, geo-redundant                          |
-| **Encryption**         | No                                   | Default, strong encryption                | Optional (server-side or client-side encryption)   |
+| **Encryption**         | No                                   | Default, strong encryption                | Optional (SSE-C)                                   |
 | **Access Control**     | OpenStack/Kubernetes roles           | OpenStack/Kubernetes roles                | IAM, ACLs, bucket policies                         |
 | **Backup**             | Managed by customer                  | Managed by customer                       | Managed by customer                                |
 | **Typical Use Cases**  | Persistent volumes for VMs/containers| Encrypted persistent volumes              | Backup, archiving, web applications, data lakes    |


### PR DESCRIPTION
We are missing a simple to read to-the-point comparison of our storage backends.
This mergerequest provides them.